### PR TITLE
Opm 1 copy to clipboard should use https

### DIFF
--- a/pygmyui/pygmy/views.py
+++ b/pygmyui/pygmy/views.py
@@ -77,7 +77,8 @@ def link_shortener(request):
 def get_short_link(request, code):
     if request.method == 'GET':
         try:
-            schema = 'https://' if request.is_secure() else 'http://'
+            # schema = 'https://' if request.is_secure() else 'http://'
+            schema = request.scheme + '://'
             url_obj = {}
             url_obj['short_url'] = (
                 schema + request.META['HTTP_HOST'] + '/' + url_obj.get(

--- a/pygmyui/templates/pygmy/index.html
+++ b/pygmyui/templates/pygmy/index.html
@@ -10,7 +10,7 @@
         <div class="col-lg-12 url-form">
             <!--Url shortener input-->
             <div class="input-group has-success centered">
-                <input type="text" class="form-control input-lg" placeholder="https://example.com" value="https://"
+                <input type="text" class="form-control input-lg" placeholder="https://example.com"
                     name="long_url" autofocus onfocus="var temp_value=this.value; this.value=''; this.value=temp_value">
                 <span class="input-group-btn">
                     <button class="btn btn-success btn-lg" type="submit">Go!</button>


### PR DESCRIPTION
Change scheme for copy to clipboard function. Remove value from input field to prevent doubled http/https insertion.

Closes #1 